### PR TITLE
use storedMarks as stack (fixes #1)

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -106,7 +106,6 @@ class Renderer
                     $item = array_merge($item, [
                         'marks' => $this->storedMarks,
                     ]);
-                    $this->storedMarks = [];
                 }
 
                 if ($class->wrapper) {
@@ -126,6 +125,8 @@ class Renderer
                 if ($child->hasChildNodes()) {
                     $nodes = array_merge($nodes, $this->renderChildren($child));
                 }
+
+                array_pop($this->storedMarks);
             }
         }
 

--- a/tests/Marks/BoldTest.php
+++ b/tests/Marks/BoldTest.php
@@ -8,7 +8,7 @@ use Scrumpy\HtmlToProseMirror\Test\TestCase;
 class BoldTest extends TestCase
 {
     /** @test */
-    public function b_and_strong_gets_rendered_correctly()
+    public function b_and_strong_get_rendered_correctly()
     {
         $html = '<p><strong>Example text using strong</strong> and <b>some example text using b</b></p>';
 

--- a/tests/Marks/ItalicTest.php
+++ b/tests/Marks/ItalicTest.php
@@ -8,7 +8,7 @@ use Scrumpy\HtmlToProseMirror\Test\TestCase;
 class ItalicTest extends TestCase
 {
     /** @test */
-    public function i_and_em_gets_rendered_correctly()
+    public function i_and_em_get_rendered_correctly()
     {
         $html = '<p><i>Example text using i</i> and <em>some example text using em</em></p>';
 

--- a/tests/Marks/NestedMarksTest.php
+++ b/tests/Marks/NestedMarksTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+
+use Scrumpy\HtmlToProseMirror\Renderer;
+use Scrumpy\HtmlToProseMirror\Test\TestCase;
+
+class NestedMarksTest extends TestCase
+{
+    /** @test */
+    public function nested_marks_get_rendered_correctly()
+    {
+        $html = '<strong>only bold <em>bold and italic</em> only bold</strong>';
+
+        $json = [
+            'type'    => 'doc',
+            'content' => [
+                [
+                    'type'  => 'text',
+                    'text'  => 'only bold ',
+                    'marks' => [
+                        [
+                            'type' => 'bold',
+                        ],
+                    ],
+                ],
+                [
+                    'type'  => 'text',
+                    'text'  => 'bold and italic',
+                    'marks' => [
+                        [
+                            'type' => 'bold',
+                        ],
+                        [
+                            'type' => 'italic',
+                        ],
+                    ],
+                ],
+                [
+                    'type'  => 'text',
+                    'text'  => ' only bold',
+                    'marks' => [
+                        [
+                            'type' => 'bold',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // $this->outputJson((new Renderer)->render($html));
+        $this->assertEquals($json, (new Renderer)->render($html));
+    }
+}


### PR DESCRIPTION
Instead of clearing the marks after every node, treat `storedMarks` as an actual stack and pop the mark after its children have been rendered.